### PR TITLE
fix: login via link

### DIFF
--- a/src/bubble/login/code.clj
+++ b/src/bubble/login/code.clj
@@ -18,7 +18,7 @@
       sha1))
 
 (defn delete-expired-codes! []
-  (sql/execute! db ["delete from sessions where expires_at < ?" (java.util.Date.)]))
+  (sql/execute! db ["delete from login_codes where expires_at < ?" (java.util.Date.)]))
 
 (defn create-code [user-id short]
   (first (sql/execute! db ["insert into login_codes (code, short_code, short, user_id, expires_at) values (?,?,?,?,?)"

--- a/src/bubble/login/session.clj
+++ b/src/bubble/login/session.clj
@@ -48,8 +48,7 @@
      db
      ["update sessions set expires_at = ? where id = ?"
       (expire-at)
-      (session-id-from-req req)])
-    true))
+      session-id])))
 
 (defn- user-from-req [req]
   (when-let [session-id (session-id-from-req req)]
@@ -69,13 +68,14 @@
   ([req]
    (user-from-req req))
   ([req {:keys [extend]}]
-   (and
-    (extend-session req)
-    (user-from-req req))))
+   (do
+     (extend-session req)
+     (user-from-req req))))
 
 (defn create-session-cookie [user-id]
   {SESSION_KEY {:value (create-session user-id)
                 :secure true
                 :http-only true
                 :same-site :strict
+                :path "/"
                 :max-age SESSION_AGE_MILLISECONDS}})


### PR DESCRIPTION
link-based login was scoping cookies to the /login-code path, resulting
in the cookie not being present on any subsequent request and therefore
treating the user as being logged out. explicitly setting the cookie
path to the root URL ("/") fixes this.