### PR TITLE
feat: logged-out redirect after login

### DIFF
--- a/src/bubble/bubbles.clj
+++ b/src/bubble/bubbles.clj
@@ -60,6 +60,7 @@
 
 (defn join-bubble-form [req]
   (let [id (get-in req [:params :id])]
+    ;; TODO: get current user if present, to change copy
     (views/base-view [[:h1 "Login to join bubble " (get-in (fetch-bubble-name id) [:bubbles/name])]
                       [:p "There are this many people in the bubble: " (get-in (count-bubble-members id) [:count])]
                       [:p "You can join this bubble here"]

--- a/src/bubble/login.clj
+++ b/src/bubble/login.clj
@@ -10,22 +10,33 @@
             [next.jdbc :as sql]
             [ring.util.response :refer [content-type redirect response]]))
 
-(defn login-error-redirect [error-message]
-  (redirect (str "/login?" (ring.util.codec/form-encode {:error error-message}))))
+(defn login-error-redirect [{error-message :error-message redirect-uri :redirect-uri}]
+  (redirect (str "/login?" (ring.util.codec/form-encode (cond-> {:error error-message}
+                                                          redirect-uri
+                                                          (assoc :redirect_uri redirect-uri))))))
+
+(defn login-with-redirect [req]
+  (redirect (str "/login?" (ring.util.codec/form-encode
+                            {:info "You'll need to log in before you can proceed to that page."
+                             :redirect_uri (:uri req)}))))
 
 (defn logged-in [req handler]
   (let [user (session/current-user req {:extend true})]
     (if user
       (handler (assoc req :current-user user))
-      (login-error-redirect "You must be logged in to see that"))))
+      (login-with-redirect req))))
 
 (defn logout [req]
   (session/log-out-user req)
   (redirect "/login"))
 
 (defn form-page [req]
-  (let [error (get-in req [:params :error])]
+  (let [error (get-in req [:params :error])
+        info (get-in req [:params :info])
+        redirect-uri (get-in req [:params :redirect_uri])]
     (views/base-view [[:h1 "Login"]
+                      (when error [:p (str "Error: " error)])
+                      (when info [:p info])
                       [:div "Welcome to *bubble thread*. We're happy you're here."]
                       [:p]
                       [:div "Bubble thread is a tool that allows members to create and collaboratively structure groups of people (bubbles!)
@@ -33,8 +44,10 @@
                       [:p]
                       [:div "Add a username and phone number below to get a login link. Then can start creating bubbles and inviting people to join them."]
                       [:p]
-                      (when error [:p (str "Error: " error)])
+
                       [:form {:action "/login" :method "post"}
+                       (when redirect-uri
+                         [:input {:name "redirect_uri" :value redirect-uri :type "hidden"}])
                        [:input {:name "username" :placeholder "username"}]
                        [:p]
                        [:input {:name "phone" :placeholder "phone number"}]
@@ -47,19 +60,24 @@
                        [:p]
                        [:button {:name "submit"} "Send me a shortcode or a link"]]])))
 
-(defn login-response [user-id]
+(defn login-response [{user-id :user-id redirect-uri :redirect-uri}]
+  (println user-id redirect-uri)
   (if user-id
-    (-> (redirect "/")
+    (-> (redirect (or redirect-uri "/"))
         (assoc :cookies (session/create-session-cookie user-id)))
-    (login-error-redirect "Invalid or expired code. Please try again.")))
+    (login-error-redirect {:error-message "Invalid or expired code. Please try again."
+                           :redirect-uri redirect-uri})))
 
 (defn handle-short-code [{:keys [session params]}]
   (let [user-id (code/user-id-for-code {:short-code (:code params)
                                         :code (:login-nonce session)})]
-    (login-response user-id)))
+    (println user-id (:redirect_uri params))
+    (login-response {:user-id user-id
+                     :redirect-uri (:redirect_uri params)})))
 
-(defn handle-code [{{code :code} :params}]
-  (login-response (code/user-id-for-code {:code code})))
+(defn handle-code [{{code :code redirect-uri :redirect_uri} :params}]
+  (login-response {:user-id (code/user-id-for-code {:code code})
+                   :redirect-uri redirect-uri}))
 
 (defn find-or-create-user! [{:keys [phone name]}]
   (sql/with-transaction [tx db]
@@ -73,6 +91,7 @@
         phone (-> params
                   :phone
                   phone/parse-phone)
+        redirect-uri (:redirect_uri params)
         use-short-code? (= "short-code" (:sms_short_code params))]
     (if phone
       (let [login-code (code/create-code (:users/id
@@ -86,17 +105,23 @@
                    "Click here to log in: "
                    config/base-url
                    "/login-code/"
-                   (:login_codes/code login-code)))})
+                   (:login_codes/code login-code)
+                   (when redirect-uri
+                     (str "?"
+                          (ring.util.codec/form-encode {:redirect_uri redirect-uri})))))})
         (if use-short-code?
           (-> (response
                (views/base-view [[:h1 "Enter the code we sent to your phone to complete log in"]
                                  [:form {:action "/login-code" :method "post"}
                                   [:input {:name "code" :placeholder "Code from SMS..."}]
+                                  (when redirect-uri
+                                    [:input {:name "redirect_uri" :value redirect-uri :type "hidden"}])
                                   [:button {:name "submit"} "Login"]]]))
               (content-type "text/html")
               (assoc :session {:login-nonce (:login_codes/code login-code)}))
           (views/base-view [[:h1 "Please check your phone for your login link"]])))
-      (login-error-redirect "Invalid phone # provided"))))
+      (login-error-redirect {:error-message "Invalid phone # provided"
+                             :redirect-uri redirect-uri}))))
 
 (comment
   (count nil)


### PR DESCRIPTION
If landing on an auth-walled page, preserve url across login flow so
that user is redirected to original page by the end of the login
process.